### PR TITLE
Index temporal aggregation codes

### DIFF
--- a/iso19139.mcp-2.0/index-fields.xsl
+++ b/iso19139.mcp-2.0/index-fields.xsl
@@ -193,8 +193,8 @@
 					</xsl:if>
 				</xsl:for-each>
 
-				<xsl:for-each select="gmd:temporalElement/mcp:EX_TemporalExtent/gmd:extent|gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent">
-					<xsl:for-each select="gml:TimePeriod">
+				<xsl:for-each select="gmd:temporalElement/mcp:EX_TemporalExtent|gmd:temporalElement/gmd:EX_TemporalExtent">
+					<xsl:for-each select="gmd:extent/gml:TimePeriod">
 						<xsl:variable name="times">
 							<xsl:call-template name="newGmlTime">
 								<xsl:with-param name="begin" select="gml:beginPosition|gml:begin/gml:TimeInstant/gml:timePosition"/>
@@ -204,6 +204,10 @@
 
 						<Field name="tempExtentBegin" string="{lower-case(substring-before($times,'|'))}" store="true" index="true"/>
 						<Field name="tempExtentEnd" string="{lower-case(substring-after($times,'|'))}" store="true" index="true"/>
+					</xsl:for-each>
+
+					<xsl:for-each select="*/mcp:MD_TemporalAggregationUnitCode/@codeListValue">
+						<Field name="temporalAggregation" string="{.}" store="false" index="true"/>
 					</xsl:for-each>
 				</xsl:for-each>
 

--- a/iso19139.mcp-2.0/loc/eng/codelists.xml
+++ b/iso19139.mcp-2.0/loc/eng/codelists.xml
@@ -496,13 +496,13 @@
 		</entry>
 		<!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
 		<entry>
-			<code>three-days</code>
+			<code>threeDays</code>
 			<label>Three days</label>
 			<description>Aggregation unit is three days</description>
 		</entry>
 		<!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
 		<entry>
-			<code>six-days</code>
+			<code>sixDays</code>
 			<label>Six days</label>
 			<description>Aggregation unit is six days</description>
 		</entry>

--- a/iso19139.mcp-2.0/present/metadata-edit.xsl
+++ b/iso19139.mcp-2.0/present/metadata-edit.xsl
@@ -153,7 +153,7 @@
 			<xsl:with-param name="schema" select="$schema"/>
 			<xsl:with-param name="edit"   select="$edit"/>
 			<xsl:with-param name="text">
-				<xsl:apply-templates mode="iso19139GetAttributeTextmcp" select="*/@codeListValue">
+				<xsl:apply-templates mode="iso19139GetAttributeTextmcp-2.0" select="*/@codeListValue">
 					<xsl:with-param name="schema" select="$schema"/>
 					<xsl:with-param name="edit"   select="$edit"/>
 				</xsl:apply-templates>
@@ -163,7 +163,7 @@
 	
 	<!-- ================================================================= -->
 
-	<xsl:template mode="iso19139GetAttributeTextmcp" match="@*">
+	<xsl:template mode="iso19139GetAttributeTextmcp-2.0" match="@*">
 		<xsl:param name="schema"/>
 		<xsl:param name="edit"/>
 		

--- a/iso19139.mcp-2.0/present/metadata.xsl
+++ b/iso19139.mcp-2.0/present/metadata.xsl
@@ -247,7 +247,7 @@
 			<xsl:with-param name="schema" select="$schema"/>
 			<xsl:with-param name="edit"   select="$edit"/>
 			<xsl:with-param name="text">
-				<xsl:apply-templates mode="iso19139GetAttributeTextmcp" select="*/@codeListValue">
+				<xsl:apply-templates mode="iso19139GetAttributeTextmcp-2.0" select="*/@codeListValue">
 					<xsl:with-param name="schema" select="$schema"/>
 					<xsl:with-param name="edit"   select="$edit"/>
 				</xsl:apply-templates>
@@ -257,7 +257,7 @@
 	
 	<!-- ================================================================= -->
 
-	<xsl:template mode="iso19139GetAttributeTextmcp" match="@*">
+	<xsl:template mode="iso19139GetAttributeTextmcp-2.0" match="@*">
 		<xsl:param name="schema"/>
 		<xsl:param name="edit"/>
 		

--- a/iso19139.mcp-2.0/schema/resources/Codelist/gmxCodelists.xml
+++ b/iso19139.mcp-2.0/schema/resources/Codelist/gmxCodelists.xml
@@ -2023,6 +2023,18 @@
 				</CodeDefinition>
 			</codeEntry>
 			<codeEntry>
+				<CodeDefinition gml:id="MD_TemporalAggregationUnitCode_threeDays">
+					<gml:description>aggregation unit is three days</gml:description>
+					<gml:identifier codeSpace="MCP version 2.0">threeDays</gml:identifier>
+				</CodeDefinition>
+			</codeEntry>
+			<codeEntry>
+				<CodeDefinition gml:id="MD_TemporalAggregationUnitCode_sixDays">
+					<gml:description>aggregation unit is six days</gml:description>
+					<gml:identifier codeSpace="MCP version 2.0">sixDays</gml:identifier>
+				</CodeDefinition>
+			</codeEntry>
+			<codeEntry>
 				<CodeDefinition gml:id="MD_TemporalAggregationUnitCode_multi-day">
 					<gml:description>aggregation unit is multi-day</gml:description>
 					<gml:identifier codeSpace="MCP version 1.2">multi-day</gml:identifier>


### PR DESCRIPTION
Fix issue with mcp 2.0 not using its own codelists
Change three-days and six-days codes to threeDays and sixDays to fit with conventions used elsewhere
Index temporal aggregation codes