### PR TITLE
Index mcp:imageLink licence-info field

### DIFF
--- a/iso19139.mcp-2.0/index-fields.xsl
+++ b/iso19139.mcp-2.0/index-fields.xsl
@@ -344,6 +344,9 @@
 				<xsl:for-each select="*/mcp:licenseLink/gmd:URL">
 					<Field name="licenseLink" string="{string(.)}" store="true" index="true" />
 				</xsl:for-each>
+				<xsl:for-each select="*/mcp:imageLink/gmd:URL">
+					<Field name="imageLink" string="{string(.)}" store="true" index="true" />
+				</xsl:for-each>
 				<xsl:for-each select="*/gmd:otherCitationDetails/gco:CharacterString">
 					<Field name="otherCitation" string="{string(.)}" store="true" index="true"/>
 				</xsl:for-each>


### PR DESCRIPTION
This will be used for the portal download-confirmation window, using the licence and citation info pulled from the metadata record.