### PR TITLE
Add transform for converting wms getMap urls to cache

### DIFF
--- a/iso19139.mcp-2.0/process/transform-wms-urls-to-cache.xsl
+++ b/iso19139.mcp-2.0/process/transform-wms-urls-to-cache.xsl
@@ -1,0 +1,19 @@
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:gco="http://www.isotc211.org/2005/gco"
+    xmlns:gmd="http://www.isotc211.org/2005/gmd"
+    xmlns:mcp="http://bluenet3.antcrc.utas.edu.au/mcp"
+    exclude-result-prefixes="mcp"
+    version="2.0">
+    
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- Convert wms links to point to cache -->
+
+    <xsl:template match="gmd:URL[../../gmd:protocol/*/text()='OGC:WMS-1.1.1-http-get-map']">
+        <gmd:URL><xsl:value-of select="replace(.,'geoserver', 'geowebcache')"/></gmd:URL>
+    </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
For when we transfer to using geowebcache as our main tile server. Haven't tested it out in geonetwork, but the transform works when run directly on a metadata xml file taken off geonetwork.

*** It might actually be better to name our geowebcache instances "tiles-systest" and "tiles-portal" or something similar so our urls aren't coupled to a particular technology.