### PR TITLE
Fix sandbox transform xsl to handle tilecache urls correctly

### DIFF
--- a/iso19139.mcp-2.0/process/transform_sandbox_urls.xsl
+++ b/iso19139.mcp-2.0/process/transform_sandbox_urls.xsl
@@ -42,7 +42,7 @@
     </xsl:template>
 	
 	<xsl:template match="gmd:URL[../../gmd:protocol/*/text()='OGC:WMS-1.1.1-http-get-map']">
-        <gmd:URL><xsl:value-of select="replace(.,'https?://geoserver-123.aodn.org.au(:443)?/geoserver', 'https://tilecache-sandbox.aodn.org.au/geowebcache/service')"/></gmd:URL>
+        <gmd:URL><xsl:value-of select="replace(.,'https?://tilecache.aodn.org.au(:443)?', 'https://tilecache-sandbox.aodn.org.au')"/></gmd:URL>
     </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
Currently the catalogue-sandbox wms entries are all pointing to production tilecache :(