### PR TITLE
Update 19139.mcp-2.0 to use new indexKey

### DIFF
--- a/iso19139.mcp-2.0/index-fields.xsl
+++ b/iso19139.mcp-2.0/index-fields.xsl
@@ -142,7 +142,7 @@
 					<Field name="dataparam" string="{$term}" store="true" index="true"/>
 					<xsl:if test="mcp:type/mcp:DP_TypeCode/@codeListValue='longName'">
 						<Field name="longParamName" string="{$term}" store="true" index="true"/>
-						<Field name="parameterUri" string="{mcp:vocabularyTermURL/gmd:URL}" store="true" index="true"/>
+						<Field name="parameterKeyword" string="{mcp:vocabularyTermURL/gmd:URL}" store="true" index="true"/>
 					</xsl:if>
 					<xsl:for-each select="mcp:vocabularyRelationship/mcp:DP_VocabularyRelationship">
 						<Field name="vocabTerm" string="{mcp:vocabularyTermURL/gmd:URL}" store="true" index="true"/>
@@ -156,7 +156,7 @@
 
 			<xsl:for-each-group select="mcp:dataParameters/mcp:DP_DataParameters/mcp:dataParameter/mcp:DP_DataParameter/mcp:platform" group-by="mcp:DP_Term/mcp:term/gco:CharacterString">
 				<Field name="platform" string="{current-grouping-key()}" store="true" index="true"/>
-				<Field name="platformUri" string="{current-group()[1]/mcp:DP_Term/mcp:vocabularyTermURL/gmd:URL}" store="true" index="true"/>
+				<Field name="platformKeyword" string="{current-group()[1]/mcp:DP_Term/mcp:vocabularyTermURL/gmd:URL}" store="true" index="true"/>
 			</xsl:for-each-group>
 
 			<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->		


### PR DESCRIPTION
Update 19139.mcp-2.0 to use new indexKey created as part of GN2 plugin to interpret 19115-3 templates located in this PR https://github.com/aodn/core-geonetwork/pull/129 