### PR TITLE
Update get-pip.py URL to use 3.5 supported version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 
-RUN wget -q https://bootstrap.pypa.io/get-pip.py \
+RUN wget -q https://bootstrap.pypa.io/3.5/get-pip.py \
     && python get-pip.py pip==18.1 \
     && rm -rf get-pip.py
 


### PR DESCRIPTION
Another one that was missed from aodn/issues#956 because github searches don't look in forks. I've checked all our other forks now and confirm that this is the only remaining one using get-pip.py.